### PR TITLE
sample loading script and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,23 @@ Unfortunately the above approach produces a lot of similar code. Now we should c
 - Eurorack it based on https://github.com/wgd-modular/utf-8-samplified
 	- gate inputs using voltage
 	- including an omp to raise output level to eurorack level
+
+## Guide to Loading Samples
+
+- install Audacity
+- load your sample to an empty audacity project
+- click on file->export audio on the menu bar
+- use the following settings
+  filename: "sample.raw"
+  folder: choose a suitable folder
+  format: Other uncompressed file
+  channels: mono
+  sample_rate: 40k
+  header: RAW (headerless)
+  encoding: Unsigned 8 bit
+- copy the resulting file to the utilities folder 
+- run renderer.py
+- now there is a resulting sample.h file that includes an array of unsigned ints
+- TODO: edit renderer.py so that it prints the size of the array
+- copy the contents of the array to the memory slot you want to replace
+- voila! 

--- a/utilities/renderer.py
+++ b/utilities/renderer.py
@@ -1,0 +1,28 @@
+import struct
+
+def read_binary_file(file_path):
+    with open(file_path, 'rb') as file:
+        data = file.read()
+    return list(data)
+
+def write_c_header_file(data, output_path):
+    with open(output_path, 'w') as file:
+        file.write('#ifndef DATA_ARRAY_H\n')
+        file.write('#define DATA_ARRAY_H\n\n')
+        file.write('unsigned char data_array[] = {\n')
+        
+        for i, byte in enumerate(data):
+            if i % 12 == 0:
+                file.write('\n    ')
+            file.write(f'{byte}, ')
+        
+        file.write('\n};\n\n')
+        file.write('#endif // DATA_ARRAY_H\n')
+
+if __name__ == "__main__":
+    input_file_path = 'sample.raw'
+    output_file_path = 'sample.h'
+    
+    data = read_binary_file(input_file_path)
+    write_c_header_file(data, output_file_path)
+    print(f"C header file '{output_file_path}' created successfully.")


### PR DESCRIPTION
will still have to modify the python script to mark the array with the size so that it makes copying easier
can also modify to open a file through a command line argument instead of being hardcoded as sample.raw - then it would generate a corresponding header file (same name) 